### PR TITLE
Adding .env files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist/
 
 # Misc
 .DS_Store
+
+# Environment variables
+.env*


### PR DESCRIPTION
Convention dictates that one should not commit .env files to git. Have added .env* files to `.gitignore`. If a user wants to document the types of environment variables required for a repo, a `sample.env` file with documentation for which variables to set is advised.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently .env files are being committed to git.

## What is the new behavior?

`.gitignore` now defaults to correct standards discouraging users from committing .env files to git. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

